### PR TITLE
Use C# 12 collections expressions

### DIFF
--- a/src/NServiceBus.CustomChecks.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.CustomChecks.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -10,7 +10,7 @@
     {
         public DefaultServer()
         {
-            typesToInclude = new List<Type>();
+            typesToInclude = [];
         }
 
         public DefaultServer(List<Type> typesToInclude)


### PR DESCRIPTION
This change satisfies the new `IDE0028` analyzer rules in the .NET 8 SDK.