### PR TITLE
Update NServiceBus packages to 10.2.0-alpha.7

### DIFF
--- a/src/NServiceBus.CustomChecks.AcceptanceTests/NServiceBus.CustomChecks.AcceptanceTests.csproj
+++ b/src/NServiceBus.CustomChecks.AcceptanceTests/NServiceBus.CustomChecks.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="10.1.4" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="10.2.0-alpha.7" />
     <PackageReference Include="NUnit" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/NServiceBus.CustomChecks/NServiceBus.CustomChecks.csproj
+++ b/src/NServiceBus.CustomChecks/NServiceBus.CustomChecks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.1.4" />
+    <PackageReference Include="NServiceBus" Version="10.2.0-alpha.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the NServiceBus package family to `10.2.0-alpha.7` in project files.

Updated package IDs:
- `NServiceBus`
- `NServiceBus.AcceptanceTesting`
- `NServiceBus.AcceptanceTests.Sources`
- `NServiceBus.PersistenceTests.Sources`
- `NServiceBus.TransportTests.Sources`

Changed `.csproj` files:
- `src/NServiceBus.CustomChecks.AcceptanceTests/NServiceBus.CustomChecks.AcceptanceTests.csproj` (`NServiceBus.AcceptanceTesting`)
- `src/NServiceBus.CustomChecks/NServiceBus.CustomChecks.csproj` (`NServiceBus`)

Generated by a LINQPad bulk-update script using Octokit.